### PR TITLE
bladeRF: Updated to post 2016.01-rc1 master

### DIFF
--- a/recipes-support/bladerf/bladerf-fpga_0.5.0.bb
+++ b/recipes-support/bladerf/bladerf-fpga_0.5.0.bb
@@ -14,11 +14,11 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;beginline=6;endline=22;md5=
 SRC_URI = "http://www.nuand.com/fpga/v${PV}/hostedx40.rbf;name=x40 \
            http://www.nuand.com/fpga/v${PV}/hostedx115.rbf;name=x115 "
 
-SRC_URI[x40.md5sum] = "03726935ab8e755f1ab2ead2e6032bb9"
-SRC_URI[x40.sha256sum] = "517de44d7ad8cdc0e88b0d3d8945a580a1c9a25fb90ec9f0b1fd34fe30a2e8ff"
+SRC_URI[x40.md5sum] = "af8ea27b4f545113db3d9b6d986f6525"
+SRC_URI[x40.sha256sum] = "179c8a09486415030431b05f537ae78b6388cbbf9e2c2e007aec1a0925912f3d"
 
-SRC_URI[x115.md5sum] = "aedc67cff1bf0b7ec237a3c122dfeccd"
-SRC_URI[x115.sha256sum] = "fbbe05efcac213cc65aeb9b1235b2341595be08b11b0d3ea9ff0071ac60ad19c"
+SRC_URI[x115.md5sum] = "8af6607afdcf9b00ddae8fbd2cf2eafa"
+SRC_URI[x115.sha256sum] = "2df44642c5d27a9934a61649e8795988ceb1a96c38cc2ee5849206cf26d43ea4"
 
 S = "${WORKDIR}"
 

--- a/recipes-support/bladerf/libbladerf_1.5.1.bb
+++ b/recipes-support/bladerf/libbladerf_1.5.1.bb
@@ -14,7 +14,7 @@ LIC_FILES_CHKSUM = " \
 DEPENDS = "libusb1 libtecla"
 
 SRC_URI = "git://github.com/Nuand/bladeRF.git;protocol=git;branch=master"
-SRCREV = "c917d33dbc5ab762ecc03151e0a76436a2267663"
+SRCREV = "1be8b76b35984a36ae4c7e1e12730b72b3a78b84"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Includes bladeRF items from 2016.01-rc1, with big-endian build fix.

Tested via `gnuradio-demo-image` on a Wandboard Quad, configured as follows:

```
Build Configuration:
BB_VERSION        = "1.28.0"
BUILD_SYS         = "x86_64-linux"
NATIVELSBSTRING   = "Ubuntu-15.04"
TARGET_SYS        = "arm-poky-linux-gnueabi"
MACHINE           = "wandboard"
DISTRO            = "poky"
DISTRO_VERSION    = "2.0"
TUNE_FEATURES     = "arm armv7a vfp thumb neon callconvention-hard cortexa9"
TARGET_FPU        = "vfp-neon"
meta              
meta-yocto        
meta-yocto-bsp    = "jethro:347347ad78c4c2502e83f2c2adff61f1ba8fed8b"
meta-oe           
meta-multimedia   
meta-networking   
meta-filesystems  
meta-python       = "jethro:4fdb203c182dae6f451ca131c0edfd5f0c99fc28"
meta-fsl-arm      = "jethro:0829a0afce089a00b81aa08a55c994b8bf9a7091"
meta-fsl-arm-extra = "jethro:95f6f731517817ae2f8b379da43ab3376005e5d4"
meta-sdr          = "bladeRF-2016.01-rc1:9a4878a5c817db640f0c9a870ea4050afa745cc8"
```