### PR TITLE
gnuradio: recommending removing some default packageconfig options.

### DIFF
--- a/recipes-core/gnuradio/gnuradio_git.bb
+++ b/recipes-core/gnuradio/gnuradio_git.bb
@@ -7,7 +7,7 @@ DEPENDS = "volk gsl fftwf python alsa-lib boost cppunit \
            swig-native python-numpy python-cheetah-native"
 
 #Available PACKAGECONFIG options are qtgui grc uhd logging orc ctrlport zeromq staticlibs
-PACKAGECONFIG ??= "qtgui grc uhd zeromq"
+PACKAGECONFIG ??= "uhd zeromq"
 
 PACKAGECONFIG[qtgui] = "-DENABLE_GR_QTGUI=ON,-DENABLE_GR_QTGUI=OFF,qt4-x11-free qwt python-pyqt, "
 PACKAGECONFIG[grc] = "-DENABLE_GRC=ON,-DENABLE_GRC=OFF,python-pygtk python-cheetah, "
@@ -211,4 +211,3 @@ EXTRA_OECMAKE = "-DENABLE_GR_ATSC=FALSE \
 "
 
 inherit distutils-base cmake pkgconfig
-


### PR DESCRIPTION
qtgui and grc options are good for GUI-based systems. I think the
embedded setup is more likely to be non-GUI / non-X based systems
where these packages are superfluous and pull in a lot of other
packages.

Removing these here is an easy local distro fix in local.conf by
appending these.
