### PR TITLE
gnuradio-dev-image: add Google protobuf support to GNU Radio Developer

### DIFF
--- a/recipes-images/packagegroups/packagegroup-sdr-base.bb
+++ b/recipes-images/packagegroups/packagegroup-sdr-base.bb
@@ -29,6 +29,7 @@ RDEPENDS_packagegroup-sdr-base-extended = "\
     openssh-sftp \
     openssh-sftp-server \
     procps \
+    protobuf \
     ntp \
     ntpdate \
     ntp-utils \
@@ -72,4 +73,3 @@ RDEPENDS_packagegroup-sdr-base-python = "\
     python-pip \
     python-mako \
 "
-


### PR DESCRIPTION
image.

Used by a number of people to serialize data over ZMQ connections.