### PR TITLE
local.conf.sample/README: Add meta-qt4 layer that provides qt4

### DIFF
--- a/README
+++ b/README
@@ -8,11 +8,17 @@ URI: git://github.com/openembedded/meta-openembedded.git
 branch: master
 revision: HEAD
 
+URI: git://git.yoctoproject.org/meta-qt4
+branch: master
+revision: HEAD
+
 From meta-openembedded, you need the following layers:
 meta-oe
 meta-filesystems
 meta-networking
 meta-python
+
+meta-qt4 provides qt4 currently required by gqrx
 
 And maybe some others. TBD.
 

--- a/conf/bblayers.conf.sample
+++ b/conf/bblayers.conf.sample
@@ -17,5 +17,6 @@ BBLAYERS ?= " \
   ##COREBASE##/../meta-fsl-arm \
   ##COREBASE##/../meta-fsl-arm-extra \
   ##COREBASE##/../meta-ti \
+  ##COREBASE##/../meta-qt4 \
   "
 


### PR DESCRIPTION
The meta-qt4 layer can provide qt4 for gqrx etc.

Signed-off-by: Moritz Fischer <moritz.fischer@ettus.com>