### PR TITLE
Adding swig-native to DEPENDS, required to build with latest OE

### DIFF
--- a/recipes-support/gr-burst/gr-burst_git.bb
+++ b/recipes-support/gr-burst/gr-burst_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/gr-vt/gr-burst"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d32239bcb673463ab874e80d47fae504"
 
-DEPENDS = "gnuradio volk python-bitarray gr-eventstream gr-mapper"
+DEPENDS = "gnuradio volk python-bitarray gr-eventstream gr-mapper swig-native"
 
 inherit setuptools cmake
 

--- a/recipes-support/gr-eventstream/gr-eventstream_git.bb
+++ b/recipes-support/gr-eventstream/gr-eventstream_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/osh/gr-eventstream"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://README;md5=94b072ac07d7c0f9b55acc17dc656824"
 
-DEPENDS = "gnuradio log4cpp"
+DEPENDS = "gnuradio log4cpp swig-native"
 
 inherit distutils-base cmake pkgconfig
 

--- a/recipes-support/gr-mapper/gr-mapper_git.bb
+++ b/recipes-support/gr-mapper/gr-mapper_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/gr-vt/gr-mapper"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d32239bcb673463ab874e80d47fae504"
 
-DEPENDS = "gnuradio"
+DEPENDS = "gnuradio log4cpp swig-native"
 
 inherit setuptools cmake
 


### PR DESCRIPTION
These all use the older swig processes and swig-native is required to complete the swig process.
Other changes are needed to the cmake files for gr-eventstream, gr-burst, and gr-mapper to get a successful compile, but this is also needed.  