### PR TITLE
recipes-support: Add swig-native to all GNU Radio OOT modules

### DIFF
--- a/recipes-support/gr-air-modes/gr-air-modes_git.bb
+++ b/recipes-support/gr-air-modes/gr-air-modes_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/bistromath/gr-ais"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
-DEPENDS = "gnuradio sqlite3 gr-osmosdr"
+DEPENDS = "gnuradio sqlite3 gr-osmosdr swig-native"
 
 inherit setuptools cmake
 

--- a/recipes-support/gr-ais/gr-ais_git.bb
+++ b/recipes-support/gr-ais/gr-ais_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/bistromath/gr-ais"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://CMakeLists.txt;md5=0ad29e89f2e64b6025da4cf91d2055fb"
 
-DEPENDS = "gnuradio"
+DEPENDS = "gnuradio swig-native"
 
 inherit setuptools cmake
 

--- a/recipes-support/gr-baz/gr-baz_git.bb
+++ b/recipes-support/gr-baz/gr-baz_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://wiki.spench.net/wiki/gr-baz"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
-DEPENDS = "gnuradio"
+DEPENDS = "gnuradio swig-native"
 
 inherit setuptools cmake pkgconfig
 

--- a/recipes-support/gr-ettus/gr-ettus_git.bb
+++ b/recipes-support/gr-ettus/gr-ettus_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/EttusResearch/gr-ettus"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
-DEPENDS = "gnuradio uhd"
+DEPENDS = "gnuradio uhd swig-native"
 
 inherit setuptools cmake
 

--- a/recipes-support/gr-framers/gr-framers_git.bb
+++ b/recipes-support/gr-framers/gr-framers_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/gr-vt/gr-framers"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d32239bcb673463ab874e80d47fae504"
 
-DEPENDS = "gnuradio cppunit"
+DEPENDS = "gnuradio cppunit swig-native"
 
 inherit setuptools cmake
 

--- a/recipes-support/gr-mac/gr-mac_git.bb
+++ b/recipes-support/gr-mac/gr-mac_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/jmalsbury/gr-mac"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://CMakeLists.txt;md5=e84f563988fbb5a8798ffd8f9d28febf"
 
-DEPENDS = "gnuradio cppunit"
+DEPENDS = "gnuradio cppunit swig-native"
 
 inherit setuptools cmake
 

--- a/recipes-support/gr-message-tools/gr-message-tools_git.bb
+++ b/recipes-support/gr-message-tools/gr-message-tools_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/gr-vt/gr-message_tools"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d32239bcb673463ab874e80d47fae504"
 
-DEPENDS = "gnuradio cppunit"
+DEPENDS = "gnuradio cppunit swig-native"
 
 inherit setuptools cmake
 

--- a/recipes-support/gr-osmosdr/gr-osmosdr_git.bb
+++ b/recipes-support/gr-osmosdr/gr-osmosdr_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://sdr.osmocom.org/trac/wiki/GrOsmoSDR"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
-DEPENDS = "gnuradio"
+DEPENDS = "gnuradio swig-native"
 
 # Use PACKAGECONFIG_pn-gr-osmosdr = "uhd hackrf"
 # to build gr-osmosdr for uhd and hackrf. This variable goes in


### PR DESCRIPTION
OE uses per-package sysroots, which means that swig-native needs to
explicitly added to each OOT module, or it won't find a native swig
executable to build the SWIG subcomponents.
Note that omitting swig-native doesn't lead to a build failure, unless
OOTs are modified to fail on missing SWIG. The default behaviour is to
simply disable Python.

Signed-off-by: Martin Braun <martin.braun@ettus.com>