### PR TITLE
recipes-support: gr-osmosdr: add python-cheetah-native as dependency

### DIFF
--- a/recipes-support/gr-osmosdr/gr-osmosdr_git.bb
+++ b/recipes-support/gr-osmosdr/gr-osmosdr_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://sdr.osmocom.org/trac/wiki/GrOsmoSDR"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
-DEPENDS = "gnuradio swig-native"
+DEPENDS = "gnuradio swig-native python-cheetah-native"
 
 # Use PACKAGECONFIG_pn-gr-osmosdr = "uhd hackrf"
 # to build gr-osmosdr for uhd and hackrf. This variable goes in


### PR DESCRIPTION
After cdf2b6ec2d there were build errors for gr-osmosdr because it was missing
the cheetah module.

Signed-off-by: Joerg Hofrichter <joerg.hofrichter@ni.com>