### PR TITLE
recipes-support: gr-mac: update patch to apply without fuzz

### DIFF
--- a/recipes-support/gr-mac/files/0001-Use-CMAKE_INSTALL_LIBDIR-to-set-LIB_SUFFIX.patch
+++ b/recipes-support/gr-mac/files/0001-Use-CMAKE_INSTALL_LIBDIR-to-set-LIB_SUFFIX.patch
@@ -12,11 +12,11 @@ Signed-off-by: Philip Balister <philip@balister.org>
  1 file changed, 8 insertions(+)
 
 diff --git a/cmake/Modules/GrPlatform.cmake b/cmake/Modules/GrPlatform.cmake
-index fbbea5f..00a53d0 100644
+index a2e4f3b..9ec4dd4 100644
 --- a/cmake/Modules/GrPlatform.cmake
 +++ b/cmake/Modules/GrPlatform.cmake
-@@ -51,4 +51,12 @@ endif()
- if(NOT DEFINED LIB_SUFFIX AND LIB64_CONVENTION AND CMAKE_SYSTEM_PROCESSOR MATCHES "64$")
+@@ -43,4 +43,12 @@ endif()
+ if(NOT DEFINED LIB_SUFFIX AND REDHAT AND CMAKE_SYSTEM_PROCESSOR MATCHES "64$")
      set(LIB_SUFFIX 64)
  endif()
 +
@@ -28,6 +28,5 @@ index fbbea5f..00a53d0 100644
 +endif()
 +
  set(LIB_SUFFIX ${LIB_SUFFIX} CACHE STRING "lib directory suffix")
--- 
-2.5.5
-
+--
+2.17.1


### PR DESCRIPTION
Fixed 0001-Use-CMAKE_INSTALL_LIBDIR-to-set-LIB_SUFFIX.patch to be applied
without fuzz.

Signed-off-by: Joerg Hofrichter <joerg.hofrichter@ni.com>