### PR TITLE
Clean up recipes for python3-antive and swig-native

### DIFF
--- a/recipes-support/gr-adsb/gr-adsb_git.bb
+++ b/recipes-support/gr-adsb/gr-adsb_git.bb
@@ -4,10 +4,10 @@ LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://COPYING;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 
-DEPENDS = "gnuradio gr-foo log4cpp cppunit swig-native python3-pybind11-native python3-native python3-numpy-native"
+DEPENDS = "gnuradio gr-foo log4cpp cppunit python3-pybind11-native python3-numpy-native"
 RDEPENDS:${PN} = "gnuradio python3-click"
 
-inherit setuptools3 cmake
+inherit setuptools3 cmake python3native
 
 export BUILD_SYS
 export HOST_SYS="${MULTIMACH_TARGET_SYS}"
@@ -20,11 +20,9 @@ SRC_URI = "git://github.com/bkerler/gr-adsb;branch=maint-3.10;protocol=https \
 S = "${WORKDIR}/git"
 
 SRCREV = "a35d5d6d7ac5fc091d121694ac51d600e77e44de"
-PYTHON_MAJMIN = "3.12"
 
 EXTRA_OECMAKE = " \
     -DCMAKE_CROSSCOMPLIING=ON \
-    -DPYTHON_INCLUDE_DIRS=${STAGING_INCDIR}/python${PYTHON_MAJMIN} \
     -DGR_PYTHON_DIR=${PYTHON_SITEPACKAGES_DIR} \
     -DENABLE_DOXYGEN=OFF \
     "

--- a/recipes-support/gr-air-modes/gr-air-modes_git.bb
+++ b/recipes-support/gr-air-modes/gr-air-modes_git.bb
@@ -3,10 +3,10 @@ HOMEPAGE = "https://github.com/bistromath/gr-ais"
 LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
-DEPENDS = "gnuradio sqlite3 gr-osmosdr python3-pybind11-native python3-native python3-numpy-native"
+DEPENDS = "gnuradio sqlite3 gr-osmosdr python3-pybind11-native  python3-numpy-native"
 RDEPENDS:${PN} = "gnuradio"
 
-inherit setuptools3 cmake
+inherit setuptools3 cmake python3native
 
 export BUILD_SYS
 export HOST_SYS="${MULTIMACH_TARGET_SYS}"

--- a/recipes-support/gr-ais/gr-ais_git.bb
+++ b/recipes-support/gr-ais/gr-ais_git.bb
@@ -3,10 +3,10 @@ HOMEPAGE = "https://github.com/bistromath/gr-ais"
 LICENSE = "GPL-3.0-or-later"
 LIC_FILES_CHKSUM = "file://CMakeLists.txt;md5=2f64aa5c06f8d667b76f72180213a1f0"
 
-DEPENDS = "gnuradio python3-pybind11-native python3-native python3-numpy-native"
+DEPENDS = "gnuradio python3-pybind11-native python3-numpy-native"
 RDEPENDS:${PN} = "gnuradio"
 
-inherit setuptools3 cmake
+inherit setuptools3 cmake python3native 
 
 export BUILD_SYS
 export HOST_SYS="${MULTIMACH_TARGET_SYS}"
@@ -21,6 +21,15 @@ SRC_URI = "git://github.com/bkerler/gr-ais;branch=maint-3.10;protocol=https \
 S = "${WORKDIR}/git"
 
 SRCREV = "fd72dd564470f55eea664271a026c892c69c6784"
+
+PYTHON_MAJMIN = "3.12"
+
+EXTRA_OECMAKE = " \
+    -DCMAKE_CROSSCOMPLIING=ON \
+    -DPYTHON_INCLUDE_DIRS=${STAGING_INCDIR}/python${PYTHON_MAJMIN} \
+    -DGR_PYTHON_DIR=${PYTHON_SITEPACKAGES_DIR} \
+    -DENABLE_DOXYGEN=OFF \
+    "
 
 INSANE_SKIP:${PN} = "dev-so"
 FILES_SOLIBSDEV = ""

--- a/recipes-support/gr-foo/gr-foo_git.bb
+++ b/recipes-support/gr-foo/gr-foo_git.bb
@@ -4,10 +4,10 @@ LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 
-DEPENDS = "gnuradio log4cpp cppunit swig-native python3-pybind11-native  python3-native python3-numpy-native"
+DEPENDS = "gnuradio log4cpp cppunit python3-pybind11-native  python3-numpy-native"
 RDEPENDS:${PN} = "gnuradio python3-click"
 
-inherit setuptools3 cmake
+inherit setuptools3 cmake python3native
 
 export BUILD_SYS
 export HOST_SYS="${MULTIMACH_TARGET_SYS}"

--- a/recipes-support/gr-ieee80211/gr-ieee80211_git.bb
+++ b/recipes-support/gr-ieee80211/gr-ieee80211_git.bb
@@ -4,10 +4,10 @@ LICENSE = "GPL-3.0-or-later"
 LIC_FILES_CHKSUM = "file://CMakeLists.txt;md5=0d30d5b085f15eea362471dff2851e51"
 
 
-DEPENDS = "gnuradio gr-foo log4cpp cppunit  python3-pybind11-native python3-native python3-numpy-native"
+DEPENDS = "gnuradio gr-foo log4cpp cppunit  python3-pybind11-native  python3-numpy-native"
 RDEPENDS:${PN} = "gnuradio python3-click"
 
-inherit setuptools3 cmake
+inherit setuptools3 cmake python3native
 
 export BUILD_SYS
 export HOST_SYS="${MULTIMACH_TARGET_SYS}"

--- a/recipes-support/gr-lfast/gr-lfast.bb
+++ b/recipes-support/gr-lfast/gr-lfast.bb
@@ -4,7 +4,7 @@ LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 
-DEPENDS = "gnuradio volk log4cpp cppunit swig-native python3-pybind11-native python3-native python3-numpy-native spdlog"
+DEPENDS = "gnuradio volk log4cpp cppunit python3-pybind11-native python3-numpy-native spdlog"
 RDEPENDS:${PN} = "gnuradio python3-click volk"
 
 inherit setuptools3 cmake pkgconfig python3native

--- a/recipes-support/gr-lora-sdr/gr-lora-sdr.bb
+++ b/recipes-support/gr-lora-sdr/gr-lora-sdr.bb
@@ -4,10 +4,10 @@ LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://CMakeLists.txt;md5=8ad2a0a5a9277845fb953e76de029ec5"
 
 
-DEPENDS = "gnuradio log4cpp cppunit python3-pybind11-native python3-native python3-numpy-native "
+DEPENDS = "gnuradio log4cpp cppunit python3-pybind11-native  python3-numpy-native "
 RDEPENDS:${PN} = "gnuradio python3-click"
 
-inherit setuptools3 cmake
+inherit setuptools3 cmake python3native
 
 export BUILD_SYS
 export HOST_SYS="${MULTIMACH_TARGET_SYS}"

--- a/recipes-support/gr-mesa/gr-mesa.bb
+++ b/recipes-support/gr-mesa/gr-mesa.bb
@@ -4,7 +4,7 @@ LICENSE = "GPL-3.0-or-later"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-3.0-or-later;md5=1c76c4cc354acaac30ed4d5eefea7245"
 
 
-DEPENDS = "gnuradio volk log4cpp cppunit swig-native python3-pybind11-native python3-native python3-numpy-native spdlog gr-lfast"
+DEPENDS = "gnuradio volk log4cpp cppunit  python3-pybind11-native  python3-numpy-native spdlog gr-lfast"
 RDEPENDS:${PN} = "gnuradio python3-click volk"
 
 inherit setuptools3 cmake pkgconfig python3native

--- a/recipes-support/gr-pager/gr-pager_git.bb
+++ b/recipes-support/gr-pager/gr-pager_git.bb
@@ -4,10 +4,10 @@ LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
 
-DEPENDS = "gnuradio log4cpp cppunit swig-native python3-pybind11-native  python3-native python3-numpy-native"
+DEPENDS = "gnuradio log4cpp cppunit python3-pybind11-native  python3-numpy-native"
 RDEPENDS:${PN} = "gnuradio python3-click"
 
-inherit setuptools3 cmake
+inherit setuptools3 cmake python3native
 
 export BUILD_SYS
 export HOST_SYS="${MULTIMACH_TARGET_SYS}"

--- a/recipes-support/gr-satellites/gr-satellites.bb
+++ b/recipes-support/gr-satellites/gr-satellites.bb
@@ -4,10 +4,10 @@ LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 
-DEPENDS = "gnuradio python3 cppunit python3-pybind11-native python3-native python3-numpy-native spdlog python3-construct python3-requests orc orc-native feh"
+DEPENDS = "gnuradio python3 cppunit python3-pybind11-native python3-numpy-native spdlog python3-construct python3-requests orc orc-native feh"
 RDEPENDS:${PN} = "gnuradio python3-click python3-construct python3-requests orc feh"
 
-inherit setuptools3 cmake
+inherit setuptools3 cmake python3native
 
 
 export BUILD_SYS


### PR DESCRIPTION
I had missed some swig-native DEPENDS.  I moved python3-native from DEPENDS to inherit python3native.  I retested the need of PYTHON_MAJMIN and confirmed it is needed in all OOT expect for gr-adbs.  At some point a need exists to look at the other OTTs Cmake commands to see what is different and fix the OOTs to build correctly. 