### PR TITLE
rtl433: add 25.02

### DIFF
--- a/recipes-support/rtl433/rtl433_git.bb
+++ b/recipes-support/rtl433/rtl433_git.bb
@@ -1,0 +1,15 @@
+DESCRIPTION = "Program to decode radio transmissions from devices on the ISM bands (and other frequencies)"
+HOMEPAGE = "https://github.com/merbanan/rtl_433/"
+
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
+
+PV = "25.02"
+SRCREV = "5cae16fbc9c1c98652676ab45d7bbf7f51e6ccea"
+SRC_URI = "git://github.com/merbanan/rtl_433.git;protocol=https;branch=master"
+
+S = "${WORKDIR}/git"
+
+DEPENDS = "libusb1 rtl-sdr openssl"
+
+inherit cmake


### PR DESCRIPTION
Rtl_433 is a program to decode radio transmissions from devices on the ISM bands (and other frequencies). It features builtin decoders for common devices:

```
root@beaglebone-new:~# rtl_433 -C si -M level -f 433.92e6 -R 37 -R 12 -R 42 -R 147 -R 189 -R 206 -R 167
rtl_433 version 25.02 branch master at 202502191252 inputs file rtl_tcp RTL-SDR with TLS Found Rafael Micro R820T tuner
[SDR] Using device 0: Realtek, RTL2838UHIDIR, SN: 00000001, "Generic RTL2832U OEM" Exact sample rate is: 250000.000414 Hz
[R82XX] PLL not locked!
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
time      : 2025-04-16 16:25:14
model     : Hideki-TS04  Rolling Code: 0
Channel   : 1            Battery   : 1             Temperature: 13.7 C       Humidity  : 62 %          Integrity : CRC
Modulation: ASK          Freq      : 433.9 MHz
RSSI      : -0.2 dB      SNR       : 11.6 dB       Noise     : -11.8 dB
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
time      : 2025-04-16 16:25:14
model     : Hideki-Wind  Rolling Code: 5
Channel   : 4            Battery   : 1             Temperature: 12.7 C       Wind Speed: 0.48 km/h     Gust Speed: 2.74 km/h     Wind Approach: 1          Wind Direction: 225.0     Integrity : CRC
Modulation: ASK          Freq      : 433.9 MHz
RSSI      : -6.2 dB      SNR       : 5.4 dB        Noise     : -11.6 dB
```