### PR TITLE
rtl433: update to import more robust cmake fix

### DIFF
--- a/recipes-support/rtl433/rtl433_git.bb
+++ b/recipes-support/rtl433/rtl433_git.bb
@@ -4,13 +4,11 @@ HOMEPAGE = "https://github.com/merbanan/rtl_433/"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
 
-PV = "25.02"
-SRCREV = "5cae16fbc9c1c98652676ab45d7bbf7f51e6ccea"
+PV = "25.02+git"
+SRCREV = "8bfb77b5c3368c1136aa39157c6be25bd6fc8e96"
 SRC_URI = "git://github.com/merbanan/rtl_433.git;protocol=https;branch=master"
 
 DEPENDS = "libusb1 rtl-sdr openssl"
 
 inherit cmake
-
-EXTRA_OECMAKE = "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
 


### PR DESCRIPTION
Upstream added a proper fix, use that instead of the -D.